### PR TITLE
✨[Feature] 채팅 도메인 설계 및 엔티티 구현

### DIFF
--- a/src/main/java/gc/goormcinema/GoormCinemaApplication.java
+++ b/src/main/java/gc/goormcinema/GoormCinemaApplication.java
@@ -2,8 +2,10 @@ package gc.goormcinema;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class GoormCinemaApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/gc/goormcinema/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,94 @@
+package gc.goormcinema.domain.chat.entity;
+
+import gc.goormcinema.domain.user.entity.User;
+import gc.goormcinema.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_messages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type", length = 20)
+    @Builder.Default
+    private MessageType messageType = MessageType.TEXT;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "file_url", length = 500)
+    private String fileUrl;
+
+    @Column(name = "file_name", length = 255)
+    private String fileName;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_status", length = 20)
+    @Builder.Default
+    private MessageStatus messageStatus = MessageStatus.SENT;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_to_message_id")
+    private ChatMessage replyToMessage;
+
+    @Column(name = "mentions", columnDefinition = "JSON")
+    private String mentions;
+
+    @Column(name = "is_edited")
+    @Builder.Default
+    private Boolean isEdited = false;
+
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(name = "edited_at")
+    private LocalDateTime editedAt;
+
+    // 비즈니스 메서드
+    public void editMessage(String newContent) {
+        this.content = newContent;
+        this.isEdited = true;
+        this.editedAt = LocalDateTime.now();
+    }
+
+    public void markAsRead() {
+        this.messageStatus = MessageStatus.READ;
+    }
+
+    public boolean isTextMessage() {
+        return this.messageType == MessageType.TEXT;
+    }
+
+    public boolean isFileMessage() {
+        return this.messageType == MessageType.FILE || this.messageType == MessageType.IMAGE;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (sentAt == null) {
+            sentAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/ChatMessageRead.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/ChatMessageRead.java
@@ -1,0 +1,47 @@
+package gc.goormcinema.domain.chat.entity;
+
+import gc.goormcinema.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_message_reads")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatMessageRead {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = false)
+    private ChatMessage message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "read_at", nullable = false)
+    private LocalDateTime readAt;
+
+    @Column(name = "device_info", length = 200)
+    private String deviceInfo;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (readAt == null) {
+            readAt = LocalDateTime.now();
+        }
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/ChatNotification.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/ChatNotification.java
@@ -1,0 +1,83 @@
+package gc.goormcinema.domain.chat.entity;
+
+import gc.goormcinema.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private ChatMessage message;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type", nullable = false, length = 20)
+    private NotificationType notificationType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "action_url", length = 500)
+    private String actionUrl;
+
+    @Column(name = "is_read")
+    @Builder.Default
+    private Boolean isRead = false;
+
+    @Column(name = "is_push_sent")
+    @Builder.Default
+    private Boolean isPushSent = false;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    // 비즈니스 메서드
+    public void markAsRead() {
+        this.isRead = true;
+        this.readAt = LocalDateTime.now();
+    }
+
+    public void markAsPushSent() {
+        this.isPushSent = true;
+    }
+
+    public boolean isExpired() {
+        return expiresAt != null && LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/ChatParticipant.java
@@ -1,0 +1,101 @@
+package gc.goormcinema.domain.chat.entity;
+
+import gc.goormcinema.domain.user.entity.User;
+import gc.goormcinema.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_participants")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatParticipant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "participant_role", nullable = false, length = 20)
+    private ParticipantRole participantRole;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "left_at")
+    private LocalDateTime leftAt;
+
+    @Column(name = "is_active")
+    @Builder.Default
+    private Boolean isActive = true;
+
+    @Column(name = "last_read_message_id")
+    private Long lastReadMessageId;
+
+    @Column(name = "last_read_at")
+    private LocalDateTime lastReadAt;
+
+    @Column(name = "unread_count")
+    @Builder.Default
+    private Integer unreadCount = 0;
+
+    @Column(name = "notification_enabled")
+    @Builder.Default
+    private Boolean notificationEnabled = true;
+
+    // 비즈니스 메서드
+    public void leaveRoom() {
+        this.isActive = false;
+        this.leftAt = LocalDateTime.now();
+    }
+
+    public void rejoinRoom() {
+        this.isActive = true;
+        this.leftAt = null;
+    }
+
+    public void updateLastReadMessage(Long messageId) {
+        this.lastReadMessageId = messageId;
+        this.lastReadAt = LocalDateTime.now();
+        this.unreadCount = 0;
+    }
+
+    public void incrementUnreadCount() {
+        this.unreadCount++;
+    }
+
+    public void enableNotification() {
+        this.notificationEnabled = true;
+    }
+
+    public void disableNotification() {
+        this.notificationEnabled = false;
+    }
+
+    public boolean isAdmin() {
+        return this.participantRole == ParticipantRole.ADMIN;
+    }
+
+    public boolean isCustomer() {
+        return this.participantRole == ParticipantRole.CUSTOMER;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (joinedAt == null) {
+            joinedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,81 @@
+package gc.goormcinema.domain.chat.entity;
+
+import gc.goormcinema.domain.user.entity.User;
+import gc.goormcinema.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "chat_rooms")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "room_code", nullable = false, unique = true, length = 50)
+    private String roomCode;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "room_type", length = 20)
+    @Builder.Default
+    private ChatRoomType roomType = ChatRoomType.INQUIRY;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "room_status", length = 20)
+    @Builder.Default
+    private ChatRoomStatus roomStatus = ChatRoomStatus.ACTIVE;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_admin")
+    private User assignedAdmin;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "closed_by")
+    private User closedBy;
+
+    @Column(name = "closed_at")
+    private java.time.LocalDateTime closedAt;
+
+    @Column(name = "last_message_id")
+    private Long lastMessageId;
+
+    @Column(name = "last_message_at")
+    private java.time.LocalDateTime lastMessageAt;
+
+    @Column(name = "total_message_count")
+    @Builder.Default
+    private Integer totalMessageCount = 0;
+
+    // 비즈니스 메서드
+    public void closeRoom(User closedBy) {
+        this.roomStatus = ChatRoomStatus.CLOSED;
+        this.closedBy = closedBy;
+        this.closedAt = java.time.LocalDateTime.now();
+    }
+
+    public void updateLastMessage(Long messageId) {
+        this.lastMessageId = messageId;
+        this.lastMessageAt = java.time.LocalDateTime.now();
+        this.totalMessageCount++;
+    }
+
+    public void assignAdmin(User admin) {
+        this.assignedAdmin = admin;
+    }
+
+    public boolean isActive() {
+        return this.roomStatus == ChatRoomStatus.ACTIVE;
+    }
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/ChatRoomStatus.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/ChatRoomStatus.java
@@ -1,0 +1,6 @@
+package gc.goormcinema.domain.chat.entity;
+
+public enum ChatRoomStatus {
+    ACTIVE,
+    CLOSED
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/ChatRoomType.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/ChatRoomType.java
@@ -1,0 +1,6 @@
+package gc.goormcinema.domain.chat.entity;
+
+public enum ChatRoomType {
+    INQUIRY,
+    GENERAL
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/MessageStatus.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/MessageStatus.java
@@ -1,0 +1,6 @@
+package gc.goormcinema.domain.chat.entity;
+
+public enum MessageStatus {
+    SENT,
+    READ
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/MessageType.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/MessageType.java
@@ -1,0 +1,7 @@
+package gc.goormcinema.domain.chat.entity;
+
+public enum MessageType {
+    TEXT,
+    FILE,
+    IMAGE
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/NotificationType.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/NotificationType.java
@@ -1,0 +1,8 @@
+package gc.goormcinema.domain.chat.entity;
+
+public enum NotificationType {
+    NEW_MESSAGE,
+    ROOM_CREATED,
+    ROOM_CLOSED,
+    MENTION
+}

--- a/src/main/java/gc/goormcinema/domain/chat/entity/ParticipantRole.java
+++ b/src/main/java/gc/goormcinema/domain/chat/entity/ParticipantRole.java
@@ -1,0 +1,6 @@
+package gc.goormcinema.domain.chat.entity;
+
+public enum ParticipantRole {
+    CUSTOMER,
+    ADMIN
+}

--- a/src/main/java/gc/goormcinema/domain/chat/repository/ChatMessageReadRepository.java
+++ b/src/main/java/gc/goormcinema/domain/chat/repository/ChatMessageReadRepository.java
@@ -1,0 +1,30 @@
+package gc.goormcinema.domain.chat.repository;
+
+import gc.goormcinema.domain.chat.entity.ChatMessageRead;
+import gc.goormcinema.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatMessageReadRepository extends JpaRepository<ChatMessageRead, Long> {
+
+    Optional<ChatMessageRead> findByMessageIdAndUser(Long messageId, User user);
+
+    List<ChatMessageRead> findByMessageId(Long messageId);
+
+    List<ChatMessageRead> findByUser(User user);
+
+    @Query("SELECT cmr FROM ChatMessageRead cmr WHERE cmr.message.room.id = :roomId AND cmr.user = :user ORDER BY cmr.readAt DESC")
+    List<ChatMessageRead> findByRoomIdAndUserOrderByReadAtDesc(@Param("roomId") Long roomId, @Param("user") User user);
+
+    @Query("SELECT COUNT(DISTINCT cmr.user) FROM ChatMessageRead cmr WHERE cmr.message.id = :messageId")
+    Long countDistinctReadersByMessageId(@Param("messageId") Long messageId);
+
+    @Query("SELECT cmr.user FROM ChatMessageRead cmr WHERE cmr.message.id = :messageId")
+    List<User> findUsersByMessageId(@Param("messageId") Long messageId);
+}

--- a/src/main/java/gc/goormcinema/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/gc/goormcinema/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,34 @@
+package gc.goormcinema.domain.chat.repository;
+
+import gc.goormcinema.domain.chat.entity.ChatMessage;
+import gc.goormcinema.domain.chat.entity.MessageStatus;
+import gc.goormcinema.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    Page<ChatMessage> findByRoomIdOrderBySentAtDesc(Long roomId, Pageable pageable);
+
+    List<ChatMessage> findByRoomIdAndSentAtAfterOrderBySentAtAsc(Long roomId, LocalDateTime afterTime);
+
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.room.id = :roomId AND cm.sender = :sender ORDER BY cm.sentAt DESC")
+    List<ChatMessage> findByRoomIdAndSenderOrderBySentAtDesc(@Param("roomId") Long roomId, @Param("sender") User sender);
+
+    @Query("SELECT COUNT(cm) FROM ChatMessage cm WHERE cm.room.id = :roomId AND cm.sentAt > :afterTime")
+    Long countByRoomIdAndSentAtAfter(@Param("roomId") Long roomId, @Param("afterTime") LocalDateTime afterTime);
+
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.room.id = :roomId AND cm.messageStatus = :status ORDER BY cm.sentAt ASC")
+    List<ChatMessage> findByRoomIdAndMessageStatusOrderBySentAtAsc(@Param("roomId") Long roomId, @Param("status") MessageStatus status);
+
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.sender = :sender AND cm.sentAt BETWEEN :startTime AND :endTime ORDER BY cm.sentAt DESC")
+    List<ChatMessage> findBySenderAndSentAtBetween(@Param("sender") User sender, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+}

--- a/src/main/java/gc/goormcinema/domain/chat/repository/ChatNotificationRepository.java
+++ b/src/main/java/gc/goormcinema/domain/chat/repository/ChatNotificationRepository.java
@@ -1,0 +1,36 @@
+package gc.goormcinema.domain.chat.repository;
+
+import gc.goormcinema.domain.chat.entity.ChatNotification;
+import gc.goormcinema.domain.chat.entity.NotificationType;
+import gc.goormcinema.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface ChatNotificationRepository extends JpaRepository<ChatNotification, Long> {
+
+    List<ChatNotification> findByUserAndIsReadOrderByCreatedAtDesc(User user, Boolean isRead);
+
+    Page<ChatNotification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+
+    @Query("SELECT cn FROM ChatNotification cn WHERE cn.user = :user AND cn.isRead = false AND (cn.expiresAt IS NULL OR cn.expiresAt > :now)")
+    List<ChatNotification> findUnreadAndNotExpiredByUser(@Param("user") User user, @Param("now") LocalDateTime now);
+
+    @Query("SELECT COUNT(cn) FROM ChatNotification cn WHERE cn.user = :user AND cn.isRead = false")
+    Long countUnreadByUser(@Param("user") User user);
+
+    List<ChatNotification> findByRoomIdAndNotificationType(Long roomId, NotificationType notificationType);
+
+    @Query("SELECT cn FROM ChatNotification cn WHERE cn.expiresAt < :now AND cn.isRead = false")
+    List<ChatNotification> findExpiredNotifications(@Param("now") LocalDateTime now);
+
+    @Query("SELECT cn FROM ChatNotification cn WHERE cn.isPushSent = false AND cn.isRead = false ORDER BY cn.createdAt ASC")
+    List<ChatNotification> findUnsentPushNotifications();
+}

--- a/src/main/java/gc/goormcinema/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/gc/goormcinema/domain/chat/repository/ChatParticipantRepository.java
@@ -1,0 +1,34 @@
+package gc.goormcinema.domain.chat.repository;
+
+import gc.goormcinema.domain.chat.entity.ChatParticipant;
+import gc.goormcinema.domain.chat.entity.ParticipantRole;
+import gc.goormcinema.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+
+    Optional<ChatParticipant> findByRoomIdAndUser(Long roomId, User user);
+
+    List<ChatParticipant> findByRoomIdAndIsActive(Long roomId, Boolean isActive);
+
+    List<ChatParticipant> findByUserAndIsActive(User user, Boolean isActive);
+
+    @Query("SELECT cp FROM ChatParticipant cp WHERE cp.room.id = :roomId AND cp.participantRole = :role AND cp.isActive = true")
+    List<ChatParticipant> findByRoomIdAndParticipantRoleAndIsActive(@Param("roomId") Long roomId, @Param("role") ParticipantRole role);
+
+    @Query("SELECT cp FROM ChatParticipant cp WHERE cp.user = :user AND cp.isActive = true AND cp.unreadCount > 0")
+    List<ChatParticipant> findByUserWithUnreadMessages(@Param("user") User user);
+
+    @Query("SELECT SUM(cp.unreadCount) FROM ChatParticipant cp WHERE cp.user = :user AND cp.isActive = true")
+    Long getTotalUnreadCountByUser(@Param("user") User user);
+
+    @Query("SELECT COUNT(cp) FROM ChatParticipant cp WHERE cp.room.id = :roomId AND cp.isActive = true")
+    Long countActiveParticipantsByRoomId(@Param("roomId") Long roomId);
+}

--- a/src/main/java/gc/goormcinema/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gc/goormcinema/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,33 @@
+package gc.goormcinema.domain.chat.repository;
+
+import gc.goormcinema.domain.chat.entity.ChatRoom;
+import gc.goormcinema.domain.chat.entity.ChatRoomStatus;
+import gc.goormcinema.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    Optional<ChatRoom> findByRoomCode(String roomCode);
+
+    List<ChatRoom> findByCreatedByAndRoomStatus(User createdBy, ChatRoomStatus roomStatus);
+
+    List<ChatRoom> findByAssignedAdminAndRoomStatus(User assignedAdmin, ChatRoomStatus roomStatus);
+
+    @Query("SELECT cr FROM ChatRoom cr WHERE cr.createdBy = :user OR cr.assignedAdmin = :user")
+    Page<ChatRoom> findByUserWithPaging(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT cr FROM ChatRoom cr WHERE cr.roomStatus = :status ORDER BY cr.lastMessageAt DESC")
+    List<ChatRoom> findByRoomStatusOrderByLastMessageAtDesc(@Param("status") ChatRoomStatus status);
+
+    @Query("SELECT COUNT(cr) FROM ChatRoom cr WHERE cr.createdBy = :user AND cr.roomStatus = :status")
+    Long countByCreatedByAndRoomStatus(@Param("user") User user, @Param("status") ChatRoomStatus status);
+}

--- a/src/main/java/gc/goormcinema/domain/chat/status/ChatErrorStatus.java
+++ b/src/main/java/gc/goormcinema/domain/chat/status/ChatErrorStatus.java
@@ -1,0 +1,63 @@
+package gc.goormcinema.domain.chat.status;
+
+import gc.goormcinema.global.common.exception.code.BaseCodeDto;
+import gc.goormcinema.global.common.exception.code.BaseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ChatErrorStatus implements BaseCodeInterface {
+
+    // Chat Room 관련 에러
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4001", "채팅방을 찾을 수 없습니다."),
+    CHAT_ROOM_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "CHAT4002", "이미 종료된 채팅방입니다."),
+    CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CHAT4003", "채팅방에 접근할 권한이 없습니다."),
+    CHAT_ROOM_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT5001", "채팅방 생성에 실패했습니다."),
+
+    // Chat Message 관련 에러
+    CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4011", "메시지를 찾을 수 없습니다."),
+    CHAT_MESSAGE_SEND_FAILED(HttpStatus.BAD_REQUEST, "CHAT4012", "메시지 전송에 실패했습니다."),
+    CHAT_MESSAGE_EDIT_DENIED(HttpStatus.FORBIDDEN, "CHAT4013", "메시지를 수정할 권한이 없습니다."),
+    CHAT_MESSAGE_DELETE_DENIED(HttpStatus.FORBIDDEN, "CHAT4014", "메시지를 삭제할 권한이 없습니다."),
+    CHAT_MESSAGE_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "CHAT4015", "메시지 내용이 비어있습니다."),
+    CHAT_MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "CHAT4016", "메시지가 너무 깁니다."),
+
+    // Chat Participant 관련 에러
+    CHAT_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4021", "채팅방 참여자를 찾을 수 없습니다."),
+    CHAT_PARTICIPANT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CHAT4022", "이미 채팅방에 참여 중입니다."),
+    CHAT_PARTICIPANT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "CHAT4023", "비활성화된 참여자입니다."),
+
+    // Chat Notification 관련 에러
+    CHAT_NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4031", "알림을 찾을 수 없습니다."),
+    CHAT_NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT5031", "알림 전송에 실패했습니다."),
+
+    // WebSocket 관련 에러
+    WEBSOCKET_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT5041", "WebSocket 연결에 실패했습니다."),
+    WEBSOCKET_MESSAGE_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT5042", "실시간 메시지 전송에 실패했습니다."),
+
+    // 권한 관련 에러
+    CHAT_ADMIN_REQUIRED(HttpStatus.FORBIDDEN, "CHAT4051", "관리자 권한이 필요합니다."),
+    CHAT_USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "CHAT4052", "인증이 필요합니다."),
+
+    // 파일 업로드 관련 에러
+    CHAT_FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "CHAT4061", "파일 업로드에 실패했습니다."),
+    CHAT_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "CHAT4062", "파일 크기가 제한을 초과했습니다."),
+    CHAT_FILE_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "CHAT4063", "지원하지 않는 파일 형식입니다.");
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess = false;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCodeDto getCode() {
+        return BaseCodeDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(isSuccess)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/gc/goormcinema/domain/user/entity/SocialAccount.java
+++ b/src/main/java/gc/goormcinema/domain/user/entity/SocialAccount.java
@@ -1,0 +1,41 @@
+package gc.goormcinema.domain.user.entity;
+
+import gc.goormcinema.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "social_account")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialAccount extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "social_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "provider", nullable = false)
+    private String provider;
+
+    @Column(name = "social_uid", nullable = false)
+    private String socialUid;
+
+    @Builder
+    public SocialAccount(User user, String provider, String socialUid) {
+        this.user = user;
+        this.provider = provider;
+        this.socialUid = socialUid;
+    }
+
+    public void updateSocialUid(String socialUid) {
+        this.socialUid = socialUid;
+    }
+}

--- a/src/main/java/gc/goormcinema/domain/user/entity/User.java
+++ b/src/main/java/gc/goormcinema/domain/user/entity/User.java
@@ -1,0 +1,66 @@
+package gc.goormcinema.domain.user.entity;
+
+import gc.goormcinema.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "email", nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(name = "password", length = 255)
+    private String password;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "phone", nullable = false, length = 20)
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private UserRole role = UserRole.USER;
+
+    @Column(name = "is_social", nullable = false)
+    private Boolean isSocial = false;
+
+    @Builder
+    public User(String email, String password, String name, String phone, UserRole role, Boolean isSocial) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.role = role != null ? role : UserRole.USER;
+        this.isSocial = isSocial != null ? isSocial : false;
+    }
+
+    public void updateProfile(String name, String phone) {
+        this.name = name;
+        this.phone = phone;
+    }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
+
+    public boolean isAdmin() {
+        return this.role == UserRole.ADMIN;
+    }
+
+    public boolean isSocialUser() {
+        return this.isSocial;
+    }
+}

--- a/src/main/java/gc/goormcinema/domain/user/entity/UserRole.java
+++ b/src/main/java/gc/goormcinema/domain/user/entity/UserRole.java
@@ -1,0 +1,13 @@
+package gc.goormcinema.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+    USER("사용자"),
+    ADMIN("관리자");
+
+    private final String description;
+}

--- a/src/main/java/gc/goormcinema/domain/user/repository/SocialAccountRepository.java
+++ b/src/main/java/gc/goormcinema/domain/user/repository/SocialAccountRepository.java
@@ -1,0 +1,29 @@
+package gc.goormcinema.domain.user.repository;
+
+import gc.goormcinema.domain.user.entity.SocialAccount;
+import gc.goormcinema.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+
+    Optional<SocialAccount> findByProviderAndSocialUid(String provider, String socialUid);
+
+    List<SocialAccount> findByUser(User user);
+
+    List<SocialAccount> findByProvider(String provider);
+
+    @Query("SELECT sa FROM SocialAccount sa WHERE sa.user = :user AND sa.provider = :provider")
+    Optional<SocialAccount> findByUserAndProvider(@Param("user") User user, @Param("provider") String provider);
+
+    boolean existsByProviderAndSocialUid(String provider, String socialUid);
+
+    @Query("SELECT COUNT(sa) FROM SocialAccount sa WHERE sa.provider = :provider")
+    Long countByProvider(@Param("provider") String provider);
+}

--- a/src/main/java/gc/goormcinema/domain/user/repository/UserRepository.java
+++ b/src/main/java/gc/goormcinema/domain/user/repository/UserRepository.java
@@ -1,0 +1,36 @@
+package gc.goormcinema.domain.user.repository;
+
+import gc.goormcinema.domain.user.entity.User;
+import gc.goormcinema.domain.user.entity.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByPhone(String phone);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByPhone(String phone);
+
+    List<User> findByRole(UserRole role);
+
+    List<User> findByIsSocial(Boolean isSocial);
+
+    @Query("SELECT u FROM User u WHERE u.role = :role AND u.deletedAt IS NULL")
+    List<User> findActiveUsersByRole(@Param("role") UserRole role);
+
+    @Query("SELECT u FROM User u WHERE u.name LIKE %:name% AND u.deletedAt IS NULL")
+    List<User> findByNameContaining(@Param("name") String name);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.role = :role AND u.deletedAt IS NULL")
+    Long countByRole(@Param("role") UserRole role);
+}

--- a/src/main/java/gc/goormcinema/global/common/base/BaseEntity.java
+++ b/src/main/java/gc/goormcinema/global/common/base/BaseEntity.java
@@ -1,35 +1,36 @@
-package gc.goormcinema.global.common.base;//
-//import jakarta.persistence.Column;
-//import jakarta.persistence.EntityListeners;
-//import jakarta.persistence.MappedSuperclass;
-//import lombok.Getter;
-//import org.springframework.data.annotation.CreatedDate;
-//import org.springframework.data.annotation.LastModifiedDate;
-//import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-//
-//import java.time.LocalDateTime;
-//
-//@Getter
-//@MappedSuperclass // JPA Entity 클래스들이 BaseTimeEntity를 상속할 경우 필드들도 칼럼으로 인식하도록 함
-//@EntityListeners(AuditingEntityListener.class) // BaseTimeEntity 클래스에 Auditing 기능을 포함시킴
-//public abstract class BaseEntity {            // AuditingEntityListener를 통해 자동으로 시간에 대한 정보를 관리
-//
-//    @CreatedDate
-//    @Column(updatable = false)
-//    private LocalDateTime createdAt;
-//
-//    @LastModifiedDate
-//    private LocalDateTime updatedAt;
-//
-//    private LocalDateTime deletedAt;
-//
-//    // 삭제 여부 확인 메서드
-//    public boolean isDeleted() {
-//        return deletedAt != null;
-//    }
-//
-//    // 삭제 처리 메서드
-//    public void delete() {
-//        deletedAt = LocalDateTime.now();
-//    }
-//}
+package gc.goormcinema.global.common.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // JPA Entity 클래스들이 BaseTimeEntity를 상속할 경우 필드들도 칼럼으로 인식하도록 함
+@EntityListeners(AuditingEntityListener.class) // BaseTimeEntity 클래스에 Auditing 기능을 포함시킴
+public abstract class BaseEntity {            // AuditingEntityListener를 통해 자동으로 시간에 대한 정보를 관리
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    // 삭제 여부 확인 메서드
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    // 삭제 처리 메서드
+    public void delete() {
+        deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/test/java/gc/goormcinema/domain/chat/entity/ChatMessageTest.java
+++ b/src/test/java/gc/goormcinema/domain/chat/entity/ChatMessageTest.java
@@ -1,0 +1,196 @@
+package gc.goormcinema.domain.chat.entity;
+
+import gc.goormcinema.domain.user.entity.User;
+import gc.goormcinema.domain.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatMessage 엔티티 테스트")
+class ChatMessageTest {
+
+    private User testUser;
+    private ChatRoom testRoom;
+    private ChatMessage testMessage;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("test@example.com")
+                .name("테스트 사용자")
+                .phone("010-1234-5678")
+                .role(UserRole.USER)
+                .isSocial(false)
+                .build();
+
+        testRoom = ChatRoom.builder()
+                .roomCode("ROOM_001")
+                .title("테스트 채팅방")
+                .roomType(ChatRoomType.INQUIRY)
+                .roomStatus(ChatRoomStatus.ACTIVE)
+                .createdBy(testUser)
+                .build();
+
+        testMessage = ChatMessage.builder()
+                .room(testRoom)
+                .sender(testUser)
+                .messageType(MessageType.TEXT)
+                .content("안녕하세요!")
+                .messageStatus(MessageStatus.SENT)
+                .isEdited(false)
+                .sentAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("ChatMessage 엔티티 생성 테스트")
+    void createChatMessage() {
+        // given
+        String content = "테스트 메시지입니다.";
+
+        // when
+        ChatMessage message = ChatMessage.builder()
+                .room(testRoom)
+                .sender(testUser)
+                .messageType(MessageType.TEXT)
+                .content(content)
+                .messageStatus(MessageStatus.SENT)
+                .isEdited(false)
+                .sentAt(LocalDateTime.now())
+                .build();
+
+        // then
+        assertThat(message.getRoom()).isEqualTo(testRoom);
+        assertThat(message.getSender()).isEqualTo(testUser);
+        assertThat(message.getMessageType()).isEqualTo(MessageType.TEXT);
+        assertThat(message.getContent()).isEqualTo(content);
+        assertThat(message.getMessageStatus()).isEqualTo(MessageStatus.SENT);
+        assertThat(message.getIsEdited()).isFalse();
+        assertThat(message.isTextMessage()).isTrue();
+        assertThat(message.isFileMessage()).isFalse();
+    }
+
+    @Test
+    @DisplayName("메시지 수정 테스트")
+    void editMessage() {
+        // given
+        String originalContent = "원본 메시지";
+        String editedContent = "수정된 메시지";
+        
+        ChatMessage message = ChatMessage.builder()
+                .room(testRoom)
+                .sender(testUser)
+                .content(originalContent)
+                .messageType(MessageType.TEXT)
+                .messageStatus(MessageStatus.SENT)
+                .isEdited(false)
+                .build();
+
+        LocalDateTime beforeEdit = LocalDateTime.now();
+
+        // when
+        message.editMessage(editedContent);
+
+        // then
+        assertThat(message.getContent()).isEqualTo(editedContent);
+        assertThat(message.getIsEdited()).isTrue();
+        assertThat(message.getEditedAt()).isAfter(beforeEdit);
+    }
+
+    @Test
+    @DisplayName("메시지 읽음 표시 테스트")
+    void markAsRead() {
+        // given
+        ChatMessage message = ChatMessage.builder()
+                .room(testRoom)
+                .sender(testUser)
+                .content("읽음 테스트")
+                .messageType(MessageType.TEXT)
+                .messageStatus(MessageStatus.SENT)
+                .build();
+
+        // when
+        message.markAsRead();
+
+        // then
+        assertThat(message.getMessageStatus()).isEqualTo(MessageStatus.READ);
+    }
+
+    @Test
+    @DisplayName("파일 메시지 생성 테스트")
+    void createFileMessage() {
+        // given
+        String fileName = "test.jpg";
+        String fileUrl = "https://example.com/files/test.jpg";
+        Long fileSize = 1024L;
+
+        // when
+        ChatMessage fileMessage = ChatMessage.builder()
+                .room(testRoom)
+                .sender(testUser)
+                .messageType(MessageType.IMAGE)
+                .content("이미지를 업로드했습니다.")
+                .fileName(fileName)
+                .fileUrl(fileUrl)
+                .fileSize(fileSize)
+                .messageStatus(MessageStatus.SENT)
+                .build();
+
+        // then
+        assertThat(fileMessage.getMessageType()).isEqualTo(MessageType.IMAGE);
+        assertThat(fileMessage.getFileName()).isEqualTo(fileName);
+        assertThat(fileMessage.getFileUrl()).isEqualTo(fileUrl);
+        assertThat(fileMessage.getFileSize()).isEqualTo(fileSize);
+        assertThat(fileMessage.isFileMessage()).isTrue();
+        assertThat(fileMessage.isTextMessage()).isFalse();
+    }
+
+    @Test
+    @DisplayName("답장 메시지 생성 테스트")
+    void createReplyMessage() {
+        // given
+        ChatMessage replyMessage = ChatMessage.builder()
+                .room(testRoom)
+                .sender(testUser)
+                .messageType(MessageType.TEXT)
+                .content("답장 메시지입니다.")
+                .replyToMessage(testMessage)
+                .messageStatus(MessageStatus.SENT)
+                .build();
+
+        // when & then
+        assertThat(replyMessage.getReplyToMessage()).isEqualTo(testMessage);
+        assertThat(replyMessage.getContent()).isEqualTo("답장 메시지입니다.");
+    }
+
+    @Test
+    @DisplayName("메시지 타입 확인 테스트")
+    void messageTypeTest() {
+        // given
+        ChatMessage textMessage = ChatMessage.builder()
+                .messageType(MessageType.TEXT)
+                .build();
+
+        ChatMessage imageMessage = ChatMessage.builder()
+                .messageType(MessageType.IMAGE)
+                .build();
+
+        ChatMessage fileMessage = ChatMessage.builder()
+                .messageType(MessageType.FILE)
+                .build();
+
+        // when & then
+        assertThat(textMessage.isTextMessage()).isTrue();
+        assertThat(textMessage.isFileMessage()).isFalse();
+
+        assertThat(imageMessage.isTextMessage()).isFalse();
+        assertThat(imageMessage.isFileMessage()).isTrue();
+
+        assertThat(fileMessage.isTextMessage()).isFalse();
+        assertThat(fileMessage.isFileMessage()).isTrue();
+    }
+}

--- a/src/test/java/gc/goormcinema/domain/chat/entity/ChatParticipantTest.java
+++ b/src/test/java/gc/goormcinema/domain/chat/entity/ChatParticipantTest.java
@@ -1,0 +1,226 @@
+package gc.goormcinema.domain.chat.entity;
+
+import gc.goormcinema.domain.user.entity.User;
+import gc.goormcinema.domain.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatParticipant 엔티티 테스트")
+class ChatParticipantTest {
+
+    private User customerUser;
+    private User adminUser;
+    private ChatRoom testRoom;
+
+    @BeforeEach
+    void setUp() {
+        customerUser = User.builder()
+                .email("customer@example.com")
+                .name("고객")
+                .phone("010-1234-5678")
+                .role(UserRole.USER)
+                .isSocial(false)
+                .build();
+
+        adminUser = User.builder()
+                .email("admin@example.com")
+                .name("관리자")
+                .phone("010-9876-5432")
+                .role(UserRole.ADMIN)
+                .isSocial(false)
+                .build();
+
+        testRoom = ChatRoom.builder()
+                .roomCode("ROOM_001")
+                .title("테스트 채팅방")
+                .roomType(ChatRoomType.INQUIRY)
+                .roomStatus(ChatRoomStatus.ACTIVE)
+                .createdBy(customerUser)
+                .build();
+    }
+
+    @Test
+    @DisplayName("ChatParticipant 엔티티 생성 테스트")
+    void createChatParticipant() {
+        // given
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        // when
+        ChatParticipant participant = ChatParticipant.builder()
+                .room(testRoom)
+                .user(customerUser)
+                .participantRole(ParticipantRole.CUSTOMER)
+                .joinedAt(joinedAt)
+                .isActive(true)
+                .unreadCount(0)
+                .notificationEnabled(true)
+                .build();
+
+        // then
+        assertThat(participant.getRoom()).isEqualTo(testRoom);
+        assertThat(participant.getUser()).isEqualTo(customerUser);
+        assertThat(participant.getParticipantRole()).isEqualTo(ParticipantRole.CUSTOMER);
+        assertThat(participant.getJoinedAt()).isEqualTo(joinedAt);
+        assertThat(participant.getIsActive()).isTrue();
+        assertThat(participant.getUnreadCount()).isEqualTo(0);
+        assertThat(participant.getNotificationEnabled()).isTrue();
+        assertThat(participant.isCustomer()).isTrue();
+        assertThat(participant.isAdmin()).isFalse();
+    }
+
+    @Test
+    @DisplayName("채팅방 나가기 테스트")
+    void leaveRoom() {
+        // given
+        ChatParticipant participant = ChatParticipant.builder()
+                .room(testRoom)
+                .user(customerUser)
+                .participantRole(ParticipantRole.CUSTOMER)
+                .isActive(true)
+                .build();
+
+        LocalDateTime beforeLeave = LocalDateTime.now();
+
+        // when
+        participant.leaveRoom();
+
+        // then
+        assertThat(participant.getIsActive()).isFalse();
+        assertThat(participant.getLeftAt()).isAfter(beforeLeave);
+    }
+
+    @Test
+    @DisplayName("채팅방 재참여 테스트")
+    void rejoinRoom() {
+        // given
+        ChatParticipant participant = ChatParticipant.builder()
+                .room(testRoom)
+                .user(customerUser)
+                .participantRole(ParticipantRole.CUSTOMER)
+                .isActive(false)
+                .leftAt(LocalDateTime.now().minusHours(1))
+                .build();
+
+        // when
+        participant.rejoinRoom();
+
+        // then
+        assertThat(participant.getIsActive()).isTrue();
+        assertThat(participant.getLeftAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("마지막 읽은 메시지 업데이트 테스트")
+    void updateLastReadMessage() {
+        // given
+        ChatParticipant participant = ChatParticipant.builder()
+                .room(testRoom)
+                .user(customerUser)
+                .participantRole(ParticipantRole.CUSTOMER)
+                .unreadCount(5)
+                .build();
+
+        Long messageId = 123L;
+        LocalDateTime beforeUpdate = LocalDateTime.now();
+
+        // when
+        participant.updateLastReadMessage(messageId);
+
+        // then
+        assertThat(participant.getLastReadMessageId()).isEqualTo(messageId);
+        assertThat(participant.getLastReadAt()).isAfter(beforeUpdate);
+        assertThat(participant.getUnreadCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("안읽은 메시지 수 증가 테스트")
+    void incrementUnreadCount() {
+        // given
+        ChatParticipant participant = ChatParticipant.builder()
+                .room(testRoom)
+                .user(customerUser)
+                .participantRole(ParticipantRole.CUSTOMER)
+                .unreadCount(3)
+                .build();
+
+        // when
+        participant.incrementUnreadCount();
+
+        // then
+        assertThat(participant.getUnreadCount()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("알림 설정 토글 테스트")
+    void toggleNotification() {
+        // given
+        ChatParticipant participant = ChatParticipant.builder()
+                .room(testRoom)
+                .user(customerUser)
+                .participantRole(ParticipantRole.CUSTOMER)
+                .notificationEnabled(true)
+                .build();
+
+        // when
+        participant.disableNotification();
+
+        // then
+        assertThat(participant.getNotificationEnabled()).isFalse();
+
+        // when
+        participant.enableNotification();
+
+        // then
+        assertThat(participant.getNotificationEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("참여자 역할 확인 테스트")
+    void participantRoleTest() {
+        // given
+        ChatParticipant customer = ChatParticipant.builder()
+                .room(testRoom)
+                .user(customerUser)
+                .participantRole(ParticipantRole.CUSTOMER)
+                .build();
+
+        ChatParticipant admin = ChatParticipant.builder()
+                .room(testRoom)
+                .user(adminUser)
+                .participantRole(ParticipantRole.ADMIN)
+                .build();
+
+        // when & then
+        assertThat(customer.isCustomer()).isTrue();
+        assertThat(customer.isAdmin()).isFalse();
+
+        assertThat(admin.isCustomer()).isFalse();
+        assertThat(admin.isAdmin()).isTrue();
+    }
+
+    @Test
+    @DisplayName("관리자 참여자 생성 테스트")
+    void createAdminParticipant() {
+        // when
+        ChatParticipant adminParticipant = ChatParticipant.builder()
+                .room(testRoom)
+                .user(adminUser)
+                .participantRole(ParticipantRole.ADMIN)
+                .joinedAt(LocalDateTime.now())
+                .isActive(true)
+                .unreadCount(0)
+                .notificationEnabled(true)
+                .build();
+
+        // then
+        assertThat(adminParticipant.getUser()).isEqualTo(adminUser);
+        assertThat(adminParticipant.getParticipantRole()).isEqualTo(ParticipantRole.ADMIN);
+        assertThat(adminParticipant.isAdmin()).isTrue();
+        assertThat(adminParticipant.isCustomer()).isFalse();
+    }
+}

--- a/src/test/java/gc/goormcinema/domain/chat/entity/ChatRoomTest.java
+++ b/src/test/java/gc/goormcinema/domain/chat/entity/ChatRoomTest.java
@@ -1,0 +1,155 @@
+package gc.goormcinema.domain.chat.entity;
+
+import gc.goormcinema.domain.user.entity.User;
+import gc.goormcinema.domain.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatRoom 엔티티 테스트")
+class ChatRoomTest {
+
+    private User testUser;
+    private User adminUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("test@example.com")
+                .name("테스트 사용자")
+                .phone("010-1234-5678")
+                .role(UserRole.USER)
+                .isSocial(false)
+                .build();
+
+        adminUser = User.builder()
+                .email("admin@example.com")
+                .name("관리자")
+                .phone("010-9876-5432")
+                .role(UserRole.ADMIN)
+                .isSocial(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("ChatRoom 엔티티 생성 테스트")
+    void createChatRoom() {
+        // given
+        String roomCode = "ROOM_001";
+        String title = "고객 문의";
+
+        // when
+        ChatRoom chatRoom = ChatRoom.builder()
+                .roomCode(roomCode)
+                .title(title)
+                .roomType(ChatRoomType.INQUIRY)
+                .roomStatus(ChatRoomStatus.ACTIVE)
+                .createdBy(testUser)
+                .totalMessageCount(0)
+                .build();
+
+        // then
+        assertThat(chatRoom.getRoomCode()).isEqualTo(roomCode);
+        assertThat(chatRoom.getTitle()).isEqualTo(title);
+        assertThat(chatRoom.getRoomType()).isEqualTo(ChatRoomType.INQUIRY);
+        assertThat(chatRoom.getRoomStatus()).isEqualTo(ChatRoomStatus.ACTIVE);
+        assertThat(chatRoom.getCreatedBy()).isEqualTo(testUser);
+        assertThat(chatRoom.getTotalMessageCount()).isEqualTo(0);
+        assertThat(chatRoom.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("채팅방 닫기 테스트")
+    void closeRoom() {
+        // given
+        ChatRoom chatRoom = ChatRoom.builder()
+                .roomCode("ROOM_002")
+                .title("테스트 채팅방")
+                .roomType(ChatRoomType.INQUIRY)
+                .roomStatus(ChatRoomStatus.ACTIVE)
+                .createdBy(testUser)
+                .build();
+
+        LocalDateTime beforeClose = LocalDateTime.now();
+
+        // when
+        chatRoom.closeRoom(adminUser);
+
+        // then
+        assertThat(chatRoom.getRoomStatus()).isEqualTo(ChatRoomStatus.CLOSED);
+        assertThat(chatRoom.getClosedBy()).isEqualTo(adminUser);
+        assertThat(chatRoom.getClosedAt()).isAfter(beforeClose);
+        assertThat(chatRoom.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("마지막 메시지 업데이트 테스트")
+    void updateLastMessage() {
+        // given
+        ChatRoom chatRoom = ChatRoom.builder()
+                .roomCode("ROOM_003")
+                .title("메시지 테스트")
+                .roomType(ChatRoomType.INQUIRY)
+                .roomStatus(ChatRoomStatus.ACTIVE)
+                .createdBy(testUser)
+                .totalMessageCount(5)
+                .build();
+
+        Long messageId = 123L;
+        LocalDateTime beforeUpdate = LocalDateTime.now();
+
+        // when
+        chatRoom.updateLastMessage(messageId);
+
+        // then
+        assertThat(chatRoom.getLastMessageId()).isEqualTo(messageId);
+        assertThat(chatRoom.getLastMessageAt()).isAfter(beforeUpdate);
+        assertThat(chatRoom.getTotalMessageCount()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("관리자 할당 테스트")
+    void assignAdmin() {
+        // given
+        ChatRoom chatRoom = ChatRoom.builder()
+                .roomCode("ROOM_004")
+                .title("관리자 할당 테스트")
+                .roomType(ChatRoomType.INQUIRY)
+                .roomStatus(ChatRoomStatus.ACTIVE)
+                .createdBy(testUser)
+                .build();
+
+        // when
+        chatRoom.assignAdmin(adminUser);
+
+        // then
+        assertThat(chatRoom.getAssignedAdmin()).isEqualTo(adminUser);
+    }
+
+    @Test
+    @DisplayName("채팅방 활성 상태 확인 테스트")
+    void isActiveTest() {
+        // given
+        ChatRoom activeChatRoom = ChatRoom.builder()
+                .roomCode("ROOM_005")
+                .title("활성 채팅방")
+                .roomStatus(ChatRoomStatus.ACTIVE)
+                .createdBy(testUser)
+                .build();
+
+        ChatRoom closedChatRoom = ChatRoom.builder()
+                .roomCode("ROOM_006")
+                .title("닫힌 채팅방")
+                .roomStatus(ChatRoomStatus.CLOSED)
+                .createdBy(testUser)
+                .build();
+
+        // when & then
+        assertThat(activeChatRoom.isActive()).isTrue();
+        assertThat(closedChatRoom.isActive()).isFalse();
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
#21 

## 📝 요약(Summary)
실시간 채팅 기능을 위한 채팅 도메인 설계 및 엔티티 구현

  - 기반 설정: BaseEntity 활성화, JPA Auditing 설정
  - User 도메인: User, SocialAccount 엔티티 및 Repository 구현
  - 채팅 핵심 엔티티: ChatRoom, ChatMessage, ChatParticipant 구현
  - 채팅 확장 엔티티: ChatMessageRead, ChatNotification 구현 (ERD 기반 확장)
  - Repository: 5개 Repository 인터페이스와 고급 쿼리 메서드
  - 에러 처리: ChatErrorStatus 16개 에러 코드 정의
  - 테스트: 3개 핵심 엔티티의 종합 단위 테스트


## 📝 리뷰 요청사항
@nick102030 User 도메인 필요해서 erd대로 User, SocialAccount 엔티티 및 Repository 구현 해놓았습니다.

## 💻 테스트 결과
